### PR TITLE
fixed jquery error

### DIFF
--- a/resources/main.js
+++ b/resources/main.js
@@ -6,7 +6,7 @@ $( function () {
 	/**
 	 * Focus on search box when 'Tab' key is pressed once
 	 */
-	$( '#searchInput' ).attr( 'tabindex', $( document ).lastTabIndex() + 1 );
+	$( '#searchInput' ).attr( 'tabindex', '999' );
 
 	/**
 	 * Desktop menu click-toggling


### PR DESCRIPTION
this feature was marked as deprecated and got removed with 1.34 and fix can be found here: https://www.mediawiki.org/wiki/ResourceLoader/Migration_guide_%28users%29#Module_deprecations